### PR TITLE
🐛(makefile) fix phony value for down task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ dev:  ## start the lms service (and its dependencies)
 
 down:  ## stop & remove all services
 	$(COMPOSE) down
-.PHONY: stop
+.PHONY: down
 
 logs:  ## get lms service logs
 	$(COMPOSE) logs -f lms


### PR DESCRIPTION
## Purpose

the .PHONY value associated to the down task has not the good value it
target the stop task. It works because down file is never created.

## Proposal

replace the .PHONY with the good value.